### PR TITLE
tensorflow-gpu is old/ Decapricated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pip
 GitPython
 keyboard
 mss
@@ -6,4 +7,4 @@ opencv-python-headless
 Pillow
 pygame
 pywin32
-tensorflow-gpu
+tensorflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pip
 GitPython
 keyboard
 mss


### PR DESCRIPTION
pypi.org/project/tensorflow-gpu"

tl;dr "they were built in the same way and both provide GPU support via Nvidia CUDA. As of December 2022, tensorflow-gpu has been removed and has been replaced with this new, empty package that generates an error upon installation. All existing versions of tensorflow-gpu are still available, but the TensorFlow team has stopped releasing any new tensorflow-gpu packages, and will not release any patches for existing tensorflow-gpu versions."